### PR TITLE
Correct misleading link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A curated list of Julia packages, resources, books and so on.
 
 Check the website link provided by [Wen Wei Tseng](https://github.com/sosiristseng):
 
-[https://gensjulia.pages.dev/]()
+[https://gensjulia.pages.dev/](https://gensjulia.pages.dev/)
 
 Contribute with PRs to the repo
 


### PR DESCRIPTION
Correct link

I dont know how this could happen, but the link was misleading:

![Screenshot_20240418_181534](https://github.com/vituri/awesome-julia/assets/6344099/ea6eba70-1e00-43ee-8df0-144e42fe1471)

